### PR TITLE
fix for single game reload

### DIFF
--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -149,18 +149,19 @@
   };
   firebase.initializeApp(config);
 
-  const dbRefObject = firebase.database().ref().child('move_time_stamp');
+  const dbRefObject = firebase.database().ref().child('<%= @game.id %>');
 
   load_time_stamp = $("body").data('time-stamp');
 
   function updateTimeStamp(data) {
-    firebase.database().ref().set({
+    firebase.database().ref().child('<%= @game.id %>').set({
       move_time_stamp: data,
     });
   }
 
   dbRefObject.on('value', snap => {
-    if (load_time_stamp < snap.val()) {
+    // console.log(snap.child('move_time_stamp').val());
+    if (load_time_stamp < snap.child('move_time_stamp').val()) {
       window.location.reload();
     }
   });


### PR DESCRIPTION
I noticed that a move on any game was causing the window reload on all games, because they were all reading from the same value in the firebase db. 
- A piece move now causes page reloads only for the same game
- Each game has its own object with timestamp values in the Firebase db